### PR TITLE
[08/28/2024] Fixed some grammatical details in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We have heard the story before. Already in 1957 the ancient programming language
 
 What happened? Thanks to the compiler, software engineers could start coding at a higher abstraction level and get more done. Did assembler programmers loose their jobs? No, but they needed to learn new things. And they had really good use of their deep knowledge in machine coding when writing source code. We still today teach about machine programming as every well-educated software engineer needs to understand what is actually happening at different abstraction levels.
 
-The programming languages of the 60'ies provided abstraction mechisms that enabled the construction of much more complex software at a much higher productivity rate. And the story repeats itself on and on in the history of software engineering: powerful abstractions enable us to create more complex software, and when it gets too complex we need to create more powerful abstractions.
+The programming languages of the 60s provided abstraction mechisms that enabled the construction of much more complex software at a much higher productivity rate. And the story repeats itself on and on in the history of software engineering: powerful abstractions enable us to create more complex software, and when it gets too complex we need to create more powerful abstractions.
 
 What Jens Huang from Nvidia actually said in Dubai in february 2024 was: "the programming language is human" and "everybody in the world is now a programmer - this is the miracle of artificial intelligence".
 
@@ -34,11 +34,11 @@ Yes, I think AI can help us with the nitty gritty, boilerplate coding details. N
 
 Thanks to AI-boosted coding we can get relived of the nitty-gritty boilerplate coding and focus on the hard stuff in Software Engineering, and we can raise the level of abstraction. Finally the experienced coders can get more time for things like requirements engineering and architecture. 
 
-Many coders today spend much of their time on nitty-gritty coding and non-interesting boilerplate. Compare to machine engineering building a factory producing things: do the machine engineers work all day by the conveyor belt doing repetivie tasks? No. But the sure need to understand what is going on in detail on the factory floor in order to be good at optimizing the flow of goods in the production. Many software engieers are stuck with low level coding of writing nitty-gritty bolierplate and crafting while loops. AI can help us here, and the more standard and bolierplaty the code is, the more reliable is AI-generated solutions.
+Many coders today spend much of their time on nitty-gritty coding and non-interesting boilerplate. Compare to machine engineering building a factory producing things: do the machine engineers work all day by the conveyor belt doing repetivie tasks? No. But the sure need to understand what is going on in detail on the factory floor in order to be good at optimizing the flow of goods in the production. Many software engineers are stuck with low level coding of writing nitty-gritty bolierplate and crafting while loops. AI can help us here, and the more standard and bolierplaty the code is, the more reliable is AI-generated solutions.
 
 #### What is bad with trained, generative AI?
 
-AI-code can have bugs anywhere, even if the code looks ok. The result from a large langugage model has an inherent stochastic element, due to the way it is constructed: the training process needs randomness to be effective at gradually adjusting the parameters of the underlying neural network. 
+AI-code can have bugs anywhere, even if the code looks ok. The result from a large language model has an inherent stochastic element, due to the way it is constructed: the training process needs randomness to be effective at gradually adjusting the parameters of the underlying neural network. 
 
 And we can't really **explain** exactly why the AI halucinated and gave us buggy code. 
 
@@ -49,16 +49,16 @@ And we can't really **explain** exactly why the AI halucinated and gave us buggy
 * Knowledge about AI: both trained AI and symbolic AI.
 * Understand the limitations of trained AI: bias, over-training, hallucination, ... 
 * Use symbolic AI and "normal" code to check and balance trained AI code both statically and at runtime.
-* Always set aside resources for human inspectio of AI-generated code.
-* Use AI to explain, critizise and experiment with your own hand-crafted code. The goal is for you to learn more and be more productive rather than handing over the control to AI.
+* Always set aside resources for human inspection of AI-generated code.
+* Use AI to explain, criticize and experiment with your own hand-crafted code. The goal is for you to learn more and be more productive rather than handing over the control to AI.
 
-Software Engineering topics that are even more important in th AI-boosted era:
+Software Engineering topics that are even more important in the AI-boosted era:
 * Software Inspection
 * Requirements Engineering
 * Software Architecture
 * High-level, safe programming languages with powerful abstractions and advanced type system that enables strong static checks
 
-In 2016 we started to use Scala as the first programming language at LTH for our Master-level programs in Computer Science and Engieering, due to its simple syntax and powerful type system making  it easy to learn while helping you find bugs already at compile time.  
+In 2016 we started to use Scala as the first programming language at LTH for our Master-level programs in Computer Science and Engineering, due to its simple syntax and powerful type system making  it easy to learn while helping you find bugs already at compile time.  
 
 #### Outro
 


### PR DESCRIPTION
Some exceptional and very interesting points. I really enjoyed the reading, and I will go ahead and point a couple grammatical things that I noticed while reading simply because that’s the least I can do:

Fixed the following:

1. 60'_ies_ -> 60s
2. Many software “_engieers_ (engineers)” are stuck with low level coding
3. The result from a large “_langugage_ (language)“
4. Always set aside resources for human “_inspectio_ (inspection)” of AI-generated code. 
5. Use AI to explain, “_critizise_ (criticize)” and experiment
6. Software Engineering topics that are even more important in “_th_ (the)” AI-boosted era 
7. LTH for our Master-level programs in Computer Science and “_Engieering_ (Engineering)”